### PR TITLE
V2026-02-17 Fix error for instances not registered in GI

### DIFF
--- a/ocenv
+++ b/ocenv
@@ -2564,7 +2564,7 @@ list_sids() {
         if [[ "${LV_TYPE}" != "asm" ]] && ! in_list "${LV_SID}" "${GV_ALIAS_LIST[@]}"
         then
           generate_alias_for_sid "${LV_SID}" "${LV_ORA_HOME}"
-          GV_DB_SID_LIST[${#GV_DB_SID_LIST[@]}]="${LV_INST_NAME}"
+          GV_DB_SID_LIST[${#GV_DB_SID_LIST[@]}]="${LV_SID}"
           GV_ALIAS_LIST[${#GV_ALIAS_LIST[@]}]="${LV_SID}"
         fi
       fi
@@ -2629,7 +2629,7 @@ list_sids() {
       if [[ "${LV_TYPE}" != "asm" ]]
       then
         generate_alias_for_sid "${LV_SID}" "${LV_ORA_HOME}"
-        GV_DB_SID_LIST[${#GV_DB_SID_LIST[@]}]="${LV_INST_NAME}"
+        GV_DB_SID_LIST[${#GV_DB_SID_LIST[@]}]="${LV_SID}"
         GV_ALIAS_LIST[${#GV_ALIAS_LIST[@]}]="${LV_SID}"
       fi
     fi

--- a/ocenv
+++ b/ocenv
@@ -56,7 +56,7 @@ fi
 ################################################################################
 
 ## Version of this script. Simply uses the date in YYYY-MM-DD format
-GV_OCENV_VERSION="2025-09-26"
+GV_OCENV_VERSION="2026-02-17"
 
 ################################################################################
 ## Environment support homogenization


### PR DESCRIPTION
Databases not registered in the GI were detected correctly, but the entry in GV_DB_SID_LIST was created empty due to a copy and paste error using the wrong variable name, causing scripts using this array to fail.