### PR TITLE
Add bat as an alternative to less

### DIFF
--- a/ocenv
+++ b/ocenv
@@ -643,8 +643,8 @@ alias via='${GV_PAGER} ${GV_INSTANCE_ALERT_LOG}'
 alias vio='${EDITOR} /etc/oratab'
 if [ "${GV_PAGER}" == "bat" ]
 then
-  alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG}' | bat --paging=never -l log
-  alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG}' | bat --paging=never -l log
+  alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG} | bat --paging=never -l log'
+  alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG} | bat --paging=never -l log'
 else
   alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG}'
   alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG}'

--- a/ocenv
+++ b/ocenv
@@ -630,7 +630,10 @@ then
 else
   alias psg='ps aux | grep -v grep | grep --color=auto'
 fi
-if [[ -x "$(command which less 2>/dev/null)" ]]
+if [[ -x "$(command which bat 2>/dev/null)" ]]
+then
+  export GV_PAGER=bat
+elif [[ -x "$(command which less 2>/dev/null)" ]]
 then
   export GV_PAGER=less
 else
@@ -638,8 +641,14 @@ else
 fi
 alias via='${GV_PAGER} ${GV_INSTANCE_ALERT_LOG}'
 alias vio='${EDITOR} /etc/oratab'
-alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG}'
-alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG}'
+if [ "${GV_PAGER}" == "bat" ]
+then
+  alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG}' | bat --paging=never -l log
+  alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG}' | bat --paging=never -l log
+else
+  alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG}'
+  alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG}'
+fi
 alias u=list_env
 unalias sql 2>/dev/null
 

--- a/ocenv
+++ b/ocenv
@@ -1997,7 +1997,12 @@ talsnr(){
   local LV_LSNR_LOG
   if LV_LSNR_LOG=$(get_lsnr_tracefile "$1")
   then
-    tail -n50 -f "${LV_LSNR_LOG}"
+    if [ "${GV_PAGER}" == "bat" ]
+    then
+      tail -n50 -f "${LV_LSNR_LOG}" | bat --paging=never -l log
+    else
+      tail -n50 -f "${LV_LSNR_LOG}"
+    fi
   fi
 }
 vilsnr(){

--- a/ocenv
+++ b/ocenv
@@ -641,7 +641,7 @@ else
 fi
 alias via='${GV_PAGER} ${GV_INSTANCE_ALERT_LOG}'
 alias vio='${EDITOR} /etc/oratab'
-if [ "${GV_PAGER}" == "bat" ]
+if [[ "${GV_PAGER}" == "bat" ]]
 then
   alias taa='tail -n50 -f ${GV_INSTANCE_ALERT_LOG} | bat --paging=never -l log'
   alias tad='tail -n50 -f ${GV_INSTANCE_DRC_LOG} | bat --paging=never -l log'
@@ -1997,7 +1997,7 @@ talsnr(){
   local LV_LSNR_LOG
   if LV_LSNR_LOG=$(get_lsnr_tracefile "$1")
   then
-    if [ "${GV_PAGER}" == "bat" ]
+    if [[ "${GV_PAGER}" == "bat" ]]
     then
       tail -n50 -f "${LV_LSNR_LOG}" | bat --paging=never -l log
     else


### PR DESCRIPTION
`bat` aka `batcat` is a cat clone with syntax highlighting and Git integration. When available, use `bat` to view or tail the Alert Log.